### PR TITLE
Update s3 bucket to sanctuary.happenate.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
 # OR AWS_PROFILE
 
-BUCKET := sanctuary-app
+BUCKET := sanctuary.happenate.com
 
 upload:
 	@aws s3 sync ./build s3://${BUCKET}


### PR DESCRIPTION
New bucket name supporting our Cloudflare-hosted domain.