### PR TITLE
Fix layout of appointment on short screen

### DIFF
--- a/src/pages/NewAppointment.jsx
+++ b/src/pages/NewAppointment.jsx
@@ -456,7 +456,7 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(3, 0, 3),
   },
   content: {
-    height: "42vh",
+    minHeight: "42vh",
     padding: theme.spacing(2, 1, 9),
   },
   title: {


### PR DESCRIPTION
On shorter screens (seen on my laptop, especially with devtools open), the appointment fields overflow the box, and the buttons appear in the middle. 