### PR TITLE
Changed token header from x-access-token to Authorization

### DIFF
--- a/src/services/authentication.js
+++ b/src/services/authentication.js
@@ -39,7 +39,7 @@ export const jwt = {
 
 const header = _ => {
     const token = localStorage.getItem('x-access-token')
-    return { headers: { 'x-access-token': token } }
+    return { headers: { 'Authorization': `Bearer ${token}` } }
 }
 
 function get(link) {


### PR DESCRIPTION
The `Authorization` header is more standardized than `x-access-token` and will play nicer with express-jwt. Our current backend already supports both.